### PR TITLE
feat: item visibility toggle + page styling (color picker)

### DIFF
--- a/app/api/public/sessions/[slug]/route.ts
+++ b/app/api/public/sessions/[slug]/route.ts
@@ -11,7 +11,7 @@ export async function GET(_req: NextRequest, { params }: { params: { slug: strin
   if (!session) return NextResponse.json({ error: "Tidak ditemukan" }, { status: 404 });
 
   const [itemsRes, promosRes, ordersCountRes] = await Promise.all([
-    supabase.from("items").select("*").eq("session_id", session.id).order("created_at"),
+    supabase.from("items").select("*").eq("session_id", session.id).neq("is_visible", false).order("created_at"),
     supabase.from("promos").select("*").eq("session_id", session.id),
     supabase.from("orders").select("id", { count: "exact" }).eq("session_id", session.id).neq("status", "deleted"),
   ]);

--- a/app/api/sessions/[id]/items/[itemId]/route.ts
+++ b/app/api/sessions/[id]/items/[itemId]/route.ts
@@ -22,7 +22,7 @@ export async function PUT(
   const owned = await verifyOwner(params.id, user.userId);
   if (!owned) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  const { name, description, price, stock_quota } = await req.json();
+  const { name, description, price, stock_quota, is_visible } = await req.json();
 
   const { data, error } = await supabase
     .from("items")
@@ -31,6 +31,7 @@ export async function PUT(
       description: description || null,
       price: Number(price),
       stock_quota: stock_quota != null ? Number(stock_quota) : null,
+      ...(is_visible !== undefined && { is_visible }),
     })
     .eq("id", params.itemId)
     .eq("session_id", params.id)

--- a/app/api/sessions/[id]/items/route.ts
+++ b/app/api/sessions/[id]/items/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const owned = await verifyOwner(params.id, user.userId);
   if (!owned) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  const { name, description, price, stock_quota } = await req.json();
+  const { name, description, price, stock_quota, is_visible } = await req.json();
   if (!name || price === undefined) {
     return NextResponse.json({ error: "Nama dan harga wajib diisi" }, { status: 400 });
   }
@@ -49,6 +49,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       description: description || null,
       price: Number(price),
       stock_quota: stock_quota != null ? Number(stock_quota) : null,
+      is_visible: is_visible !== false,
     })
     .select()
     .single();

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -29,11 +29,11 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (!session) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
   const body = await req.json();
-  const { title, intro_text, footer_text, opens_at, closes_at, is_active } = body;
+  const { title, intro_text, footer_text, opens_at, closes_at, is_active, primary_color, accent_color } = body;
 
   const { data, error } = await supabase
     .from("sessions")
-    .update({ title, intro_text, footer_text, opens_at, closes_at, is_active })
+    .update({ title, intro_text, footer_text, opens_at, closes_at, is_active, primary_color: primary_color || null, accent_color: accent_color || null })
     .eq("id", params.id)
     .select()
     .single();

--- a/app/dashboard/[sessionId]/page.tsx
+++ b/app/dashboard/[sessionId]/page.tsx
@@ -20,6 +20,8 @@ interface Session {
   closes_at: string | null;
   is_active: boolean;
   owner_id: string;
+  primary_color: string | null;
+  accent_color: string | null;
 }
 interface Item {
   id: string;
@@ -27,6 +29,7 @@ interface Item {
   description: string | null;
   price: number;
   stock_quota: number | null;
+  is_visible: boolean;
 }
 interface Promo {
   id: string;
@@ -78,7 +81,9 @@ export default function SessionPage() {
   const [editPromo, setEditPromo] = useState<Partial<Promo> | null>(null);
   const [showPayment, setShowPayment] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
+  const [showStylingModal, setShowStylingModal] = useState(false);
   const [savingSettings, setSavingSettings] = useState(false);
+  const [savingStyling, setSavingStyling] = useState(false);
   const [tabLoading, setTabLoading] = useState(false);
   const [copied, setCopied] = useState(false);
   const importRef = useRef<HTMLInputElement>(null);
@@ -93,6 +98,11 @@ export default function SessionPage() {
     opens_at: "",
     closes_at: "",
     is_active: true,
+  });
+
+  const [styling, setStyling] = useState({
+    primary_color: "",
+    accent_color: "",
   });
 
   useEffect(() => {
@@ -119,6 +129,10 @@ export default function SessionPage() {
       opens_at: data.opens_at ? data.opens_at.slice(0, 16) : "",
       closes_at: data.closes_at ? data.closes_at.slice(0, 16) : "",
       is_active: data.is_active ?? true,
+    });
+    setStyling({
+      primary_color: data.primary_color || "",
+      accent_color: data.accent_color || "",
     });
     setLoading(false);
     fetchItems();
@@ -162,7 +176,7 @@ export default function SessionPage() {
     const res = await fetch(`/api/sessions/${sessionId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(settings),
+      body: JSON.stringify({ ...settings, primary_color: styling.primary_color || null, accent_color: styling.accent_color || null }),
     });
     setSavingSettings(false);
     if (res.ok) {
@@ -171,6 +185,37 @@ export default function SessionPage() {
       setShowSettingsModal(false);
       toast.success("Pengaturan disimpan");
     } else toast.error("Gagal menyimpan");
+  };
+
+  const saveStyling = async () => {
+    setSavingStyling(true);
+    const res = await fetch(`/api/sessions/${sessionId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...settings, primary_color: styling.primary_color || null, accent_color: styling.accent_color || null }),
+    });
+    setSavingStyling(false);
+    if (res.ok) {
+      const data = await res.json();
+      setSession(data);
+      setStyling({ primary_color: data.primary_color || "", accent_color: data.accent_color || "" });
+      setShowStylingModal(false);
+      toast.success("Tampilan disimpan");
+    } else toast.error("Gagal menyimpan");
+  };
+
+  const handleToggleVisibility = async (item: Item) => {
+    const newVisible = !item.is_visible;
+    setItems((prev) => prev.map((i) => i.id === item.id ? { ...i, is_visible: newVisible } : i));
+    const res = await fetch(`/api/sessions/${sessionId}/items/${item.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: item.name, description: item.description, price: item.price, stock_quota: item.stock_quota, is_visible: newVisible }),
+    });
+    if (!res.ok) {
+      setItems((prev) => prev.map((i) => i.id === item.id ? { ...i, is_visible: item.is_visible } : i));
+      toast.error("Gagal mengubah visibilitas");
+    }
   };
 
   const handleSaveItem = async (data: Omit<Item, "id">) => {
@@ -350,14 +395,73 @@ export default function SessionPage() {
                 <a href={`/p/${session?.slug}`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-400 hover:text-teal-600 shrink-0">↗</a>
               </div>
             </div>
-            <button
-              onClick={() => setShowSettingsModal(true)}
-              className="shrink-0 border border-gray-200 text-gray-600 font-medium px-3 py-2 rounded-xl hover:border-teal-600 hover:text-teal-600 transition-colors text-sm"
-            >
-              {lang.btn_edit_settings}
-            </button>
+            <div className="flex gap-2 shrink-0">
+              <button
+                onClick={() => setShowStylingModal(true)}
+                className="border border-gray-200 text-gray-600 font-medium px-3 py-2 rounded-xl hover:border-purple-500 hover:text-purple-600 transition-colors text-sm"
+              >
+                🎨 {lang.btn_styling}
+              </button>
+              <button
+                onClick={() => setShowSettingsModal(true)}
+                className="border border-gray-200 text-gray-600 font-medium px-3 py-2 rounded-xl hover:border-teal-600 hover:text-teal-600 transition-colors text-sm"
+              >
+                {lang.btn_edit_settings}
+              </button>
+            </div>
           </div>
         </div>
+
+        {/* Styling Modal */}
+        {showStylingModal && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 px-4">
+            <div className="bg-white rounded-2xl w-full max-w-sm shadow-xl">
+              <div className="bg-purple-600 rounded-t-2xl px-6 py-4 text-white">
+                <h2 className="font-bold text-lg">🎨 {lang.styling_title}</h2>
+              </div>
+              <div className="px-6 py-5 space-y-5">
+                <div>
+                  <label className="text-sm font-medium text-gray-700 block mb-2">{lang.styling_primary}</label>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="color"
+                      value={styling.primary_color || "#0d9488"}
+                      onChange={(e) => setStyling((s) => ({ ...s, primary_color: e.target.value }))}
+                      className="w-12 h-10 rounded-lg border border-gray-200 cursor-pointer p-0.5"
+                    />
+                    <span className="text-sm text-gray-500 font-mono">{styling.primary_color || "#0d9488"}</span>
+                    {styling.primary_color && (
+                      <button onClick={() => setStyling((s) => ({ ...s, primary_color: "" }))} className="text-xs text-gray-400 hover:text-red-400">Reset</button>
+                    )}
+                  </div>
+                  <div className="mt-2 h-8 rounded-lg transition-all" style={{ background: styling.primary_color || "#0d9488" }} />
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-700 block mb-2">{lang.styling_accent}</label>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="color"
+                      value={styling.accent_color || "#C9A84C"}
+                      onChange={(e) => setStyling((s) => ({ ...s, accent_color: e.target.value }))}
+                      className="w-12 h-10 rounded-lg border border-gray-200 cursor-pointer p-0.5"
+                    />
+                    <span className="text-sm text-gray-500 font-mono">{styling.accent_color || "#C9A84C"}</span>
+                    {styling.accent_color && (
+                      <button onClick={() => setStyling((s) => ({ ...s, accent_color: "" }))} className="text-xs text-gray-400 hover:text-red-400">Reset</button>
+                    )}
+                  </div>
+                  <div className="mt-2 h-8 rounded-lg transition-all" style={{ background: styling.accent_color || "#C9A84C" }} />
+                </div>
+              </div>
+              <div className="px-6 pb-6 flex gap-3">
+                <button onClick={() => setShowStylingModal(false)} className="flex-1 border border-gray-200 text-gray-600 font-medium py-2.5 rounded-xl hover:bg-gray-50 transition-colors">{lang.btn_cancel}</button>
+                <button onClick={saveStyling} disabled={savingStyling} className="flex-1 bg-purple-600 text-white font-semibold py-2.5 rounded-xl hover:bg-purple-700 transition-colors disabled:opacity-60">
+                  {savingStyling ? "Menyimpan..." : lang.btn_save}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Settings Modal */}
         {showSettingsModal && (
@@ -462,18 +566,25 @@ export default function SessionPage() {
                       <th className="text-left px-4 py-3 font-semibold text-gray-600">{lang.item_name}</th>
                       <th className="text-right px-4 py-3 font-semibold text-gray-600">{lang.item_price}</th>
                       <th className="text-right px-4 py-3 font-semibold text-gray-600">{lang.item_quota}</th>
+                      <th className="text-center px-4 py-3 font-semibold text-gray-600">{lang.item_visible}</th>
                       <th className="px-4 py-3"></th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-50">
                     {items.map((item) => (
-                      <tr key={item.id} className="bg-white hover:bg-gray-50">
+                      <tr key={item.id} className={`bg-white hover:bg-gray-50 ${item.is_visible === false ? "opacity-50" : ""}`}>
                         <td className="px-4 py-3">
                           <div className="font-medium text-gray-900">{item.name}</div>
                           {item.description && <div className="text-xs text-gray-400 mt-0.5 truncate max-w-xs">{item.description}</div>}
                         </td>
                         <td className="px-4 py-3 text-right font-medium text-teal-700">{formatRp(item.price)}</td>
                         <td className="px-4 py-3 text-right text-gray-500">{item.stock_quota ?? lang.item_no_quota}</td>
+                        <td className="px-4 py-3 text-center">
+                          <Toggle
+                            checked={item.is_visible !== false}
+                            onChange={() => handleToggleVisibility(item)}
+                          />
+                        </td>
                         <td className="px-4 py-3 text-right">
                           <div className="flex gap-2 justify-end">
                             <button onClick={() => setEditItem(item)} className="text-xs text-teal-600 font-semibold hover:underline">{lang.btn_edit}</button>

--- a/app/dashboard/[sessionId]/page.tsx
+++ b/app/dashboard/[sessionId]/page.tsx
@@ -29,7 +29,7 @@ interface Item {
   description: string | null;
   price: number;
   stock_quota: number | null;
-  is_visible: boolean;
+  is_visible?: boolean;
 }
 interface Promo {
   id: string;

--- a/app/p/[slug]/page.tsx
+++ b/app/p/[slug]/page.tsx
@@ -16,6 +16,8 @@ interface SessionData {
   closes_at: string | null;
   opens_at: string | null;
   slug: string;
+  primary_color: string | null;
+  accent_color: string | null;
 }
 interface Item {
   id: string;
@@ -101,7 +103,7 @@ export default function CustomerPage() {
       setSessionOrderCount(ordersCountRes.count || 0);
 
       setSessionData(session);
-      setItems(itemsRes.data || []);
+      setItems((itemsRes.data || []).filter((item) => item.is_visible !== false));
       setPromos(promosRes.data || []);
       const s = session;
       if (!s.is_active) { setClosed(true); }
@@ -305,7 +307,10 @@ export default function CustomerPage() {
       <CountdownBanner closesAt={sessionData.closes_at} />
 
       {/* Hero */}
-      <div className="bg-gradient-to-br from-teal-600 to-teal-800 text-white px-4 py-10">
+      <div
+        className="text-white px-4 py-10"
+        style={{ background: sessionData.primary_color || "linear-gradient(135deg, #0d9488, #115e59)" }}
+      >
         <div className="max-w-xl mx-auto text-center">
           <h1 className="text-2xl md:text-3xl font-extrabold mb-3">{sessionData.title}</h1>
           {sessionData.intro_text && <p className="text-teal-100 text-sm leading-relaxed">{sessionData.intro_text}</p>}
@@ -325,7 +330,7 @@ export default function CustomerPage() {
           if (p.promo_type === "before_deadline" && p.deadline) return new Date(p.deadline) > new Date();
           return p.promo_type === "first_n_customers" || p.promo_type === "coupon";
         }).map((promo) => (
-          <div key={promo.id} className="rounded-xl px-4 py-3 text-sm font-medium" style={{ background: "#C9A84C", color: "white" }}>
+          <div key={promo.id} className="rounded-xl px-4 py-3 text-sm font-medium" style={{ background: sessionData.accent_color || "#C9A84C", color: "white" }}>
             🎁 {promo.name} — {formatRp(promo.promo_price)}
             {promo.coupon_code && <span className="ml-2 bg-white/20 px-2 py-0.5 rounded text-xs">Kode: {promo.coupon_code}</span>}
           </div>
@@ -361,7 +366,7 @@ export default function CustomerPage() {
                         </span>
                       )}
                       {isPromo && !isOutOfStock && !firstNStatus && (
-                        <span className="text-xs px-2 py-0.5 rounded-full font-bold" style={{ background: "#C9A84C", color: "white" }}>{lang.customer_promo_badge}</span>
+                        <span className="text-xs px-2 py-0.5 rounded-full font-bold" style={{ background: sessionData.accent_color || "#C9A84C", color: "white" }}>{lang.customer_promo_badge}</span>
                       )}
                     </div>
                     {item.description && <p className="text-xs text-gray-400 mt-0.5">{item.description}</p>}

--- a/lib/lang.ts
+++ b/lib/lang.ts
@@ -182,6 +182,15 @@ export const id = {
   countdown_seconds: "detik",
   customer_qty: "Qty",
   customer_add_to_cart: "Tambah",
+
+  // Item visibility
+  item_visible: "Tampil",
+
+  // Styling modal
+  btn_styling: "Styling",
+  styling_title: "Tampilan Halaman",
+  styling_primary: "Warna Primer (Hero)",
+  styling_accent: "Warna Aksen (Promo & Badge)",
 };
 
 export const en = {
@@ -368,6 +377,15 @@ export const en = {
   countdown_seconds: "seconds",
   customer_qty: "Qty",
   customer_add_to_cart: "Add",
+
+  // Item visibility
+  item_visible: "Visible",
+
+  // Styling modal
+  btn_styling: "Styling",
+  styling_title: "Page Styling",
+  styling_primary: "Primary Color (Hero)",
+  styling_accent: "Accent Color (Promo & Badge)",
 };
 
 export type LangKeys = keyof typeof id;

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -25,6 +25,8 @@ create table sessions (
   opens_at timestamptz,
   closes_at timestamptz,
   is_active boolean default true,
+  primary_color text,
+  accent_color text,
   created_at timestamptz default now()
 );
 
@@ -36,6 +38,7 @@ create table items (
   description text,
   price integer not null default 0,
   stock_quota integer,
+  is_visible boolean default true,
   created_at timestamptz default now()
 );
 
@@ -98,3 +101,8 @@ create index on orders(session_id);
 create index on orders(session_id, queue_number);
 create index on order_items(order_id);
 create index on owner_payments(session_id, payment_status);
+
+-- Migration: run these if upgrading an existing database
+-- alter table items add column if not exists is_visible boolean default true;
+-- alter table sessions add column if not exists primary_color text;
+-- alter table sessions add column if not exists accent_color text;


### PR DESCRIPTION
- Add is_visible toggle per item in Products tab with optimistic UI update Hidden items are dimmed in dashboard and excluded from the customer page
- Add Styling modal with primary color (hero background) and accent color (promo banners + PROMO badge) pickers; colors saved to sessions table
- Update sessions API PUT to persist primary_color and accent_color
- Update items API POST/PUT to handle is_visible field
- Filter is_visible != false in public sessions API and customer page fetch
- Add schema migration comments for new columns
- Add lang keys: item_visible, btn_styling, styling_title, styling_primary, styling_accent

https://claude.ai/code/session_01F2SVcHDeuLhnmSKJMKgdQU