### PR TITLE
Add superadmin panel with full user and transaction management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ JWT_SECRET=change-me-to-a-long-random-secret
 
 # App URL (for Vercel, set to your deployment URL)
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Superadmin panel (keep these secret)
+SUPERADMIN_PATH=sa-panel-x7k2q
+SUPERADMIN_EMAIL=admin@example.com
+SUPERADMIN_PASSWORD=changeme
+SA_JWT_SECRET=change-me-to-a-long-random-secret-for-sa

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: NextRequest) {
 
   const { data: user } = await supabase
     .from("users")
-    .select("id, email, password_hash")
+    .select("id, email, password_hash, is_banned")
     .eq("email", email)
     .single();
 
@@ -23,6 +23,16 @@ export async function POST(req: NextRequest) {
   if (!valid) {
     return NextResponse.json({ error: "Email atau password salah" }, { status: 401 });
   }
+
+  if (user.is_banned) {
+    return NextResponse.json(
+      { error: "Akun kamu dinonaktifkan. Hubungi kami untuk informasi lebih lanjut." },
+      { status: 403 }
+    );
+  }
+
+  // Update last sign in timestamp
+  await supabase.from("users").update({ last_sign_in: new Date().toISOString() }).eq("id", user.id);
 
   const token = await signToken({ userId: user.id, email: user.email });
   const cookieOpts = getCookieOptions();

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getAuthUserFromRequest } from "@/lib/auth";
+
+export async function GET(req: NextRequest) {
+  const user = await getAuthUserFromRequest(req);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data } = await supabase
+    .from("users")
+    .select("id, email, business_name, wa_number, role, is_banned")
+    .eq("id", user.userId)
+    .single();
+
+  if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  if (data.is_banned) {
+    return NextResponse.json({ error: "banned" }, { status: 403 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/app/api/sa/auth/login/route.ts
+++ b/app/api/sa/auth/login/route.ts
@@ -1,0 +1,31 @@
+// SUPERADMIN ONLY
+import { NextRequest, NextResponse } from "next/server";
+import { signSaToken, getSaCookieOptions } from "@/lib/saAuth";
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
+
+  const expectedEmail = process.env.SUPERADMIN_EMAIL;
+  const expectedPassword = process.env.SUPERADMIN_PASSWORD;
+
+  if (!expectedEmail || !expectedPassword) {
+    return NextResponse.json({ error: "Superadmin not configured" }, { status: 500 });
+  }
+
+  if (email !== expectedEmail || password !== expectedPassword) {
+    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+  }
+
+  const token = await signSaToken();
+  const opts = getSaCookieOptions();
+
+  const res = NextResponse.json({ success: true });
+  res.cookies.set(opts.name, token, {
+    httpOnly: opts.httpOnly,
+    secure: opts.secure,
+    sameSite: opts.sameSite,
+    path: opts.path,
+    maxAge: opts.maxAge,
+  });
+  return res;
+}

--- a/app/api/sa/auth/logout/route.ts
+++ b/app/api/sa/auth/logout/route.ts
@@ -1,0 +1,8 @@
+// SUPERADMIN ONLY
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const res = NextResponse.json({ success: true });
+  res.cookies.set("sa_token", "", { maxAge: 0, path: "/" });
+  return res;
+}

--- a/app/api/sa/transactions/[id]/approve/route.ts
+++ b/app/api/sa/transactions/[id]/approve/route.ts
@@ -1,0 +1,23 @@
+// SUPERADMIN ONLY
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getSaTokenFromRequest, verifySaToken } from "@/lib/saAuth";
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const token = await getSaTokenFromRequest(req);
+  if (!token || !(await verifySaToken(token))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("owner_payments")
+    .update({ payment_status: "paid" })
+    .eq("id", params.id)
+    .eq("payment_status", "pending")
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: "Not found or already approved" }, { status: 404 });
+  return NextResponse.json(data);
+}

--- a/app/api/sa/transactions/bulk-approve/route.ts
+++ b/app/api/sa/transactions/bulk-approve/route.ts
@@ -1,0 +1,20 @@
+// SUPERADMIN ONLY
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getSaTokenFromRequest, verifySaToken } from "@/lib/saAuth";
+
+export async function POST(req: NextRequest) {
+  const token = await getSaTokenFromRequest(req);
+  if (!token || !(await verifySaToken(token))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("owner_payments")
+    .update({ payment_status: "paid" })
+    .eq("payment_status", "pending")
+    .select("id");
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ approved_count: (data || []).length });
+}

--- a/app/api/sa/transactions/route.ts
+++ b/app/api/sa/transactions/route.ts
@@ -1,0 +1,48 @@
+// SUPERADMIN ONLY
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getSaTokenFromRequest, verifySaToken } from "@/lib/saAuth";
+
+export async function GET(req: NextRequest) {
+  const token = await getSaTokenFromRequest(req);
+  if (!token || !(await verifySaToken(token))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("owner_payments")
+    .select(`
+      id,
+      payment_type,
+      slots_purchased,
+      amount_paid,
+      payment_status,
+      created_at,
+      owner_id,
+      session_id,
+      users!owner_id (business_name, wa_number),
+      sessions!session_id (title)
+    `)
+    .order("created_at", { ascending: false });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  type TxRow = { payment_status: string; amount_paid: number };
+  const rows = (data || []) as TxRow[];
+
+  const totalRevenue = rows
+    .filter((p) => p.payment_status === "paid")
+    .reduce((sum: number, p) => sum + p.amount_paid, 0);
+  const totalPending = rows
+    .filter((p) => p.payment_status === "pending")
+    .reduce((sum: number, p) => sum + p.amount_paid, 0);
+
+  return NextResponse.json({
+    transactions: data || [],
+    summary: {
+      total_revenue: totalRevenue,
+      total_pending: totalPending,
+      total_count: rows.length,
+    },
+  });
+}

--- a/app/api/sa/users/[id]/ban/route.ts
+++ b/app/api/sa/users/[id]/ban/route.ts
@@ -1,0 +1,41 @@
+// SUPERADMIN ONLY
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getSaTokenFromRequest, verifySaToken } from "@/lib/saAuth";
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const token = await getSaTokenFromRequest(req);
+  if (!token || !(await verifySaToken(token))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: user } = await supabase
+    .from("users")
+    .select("is_banned")
+    .eq("id", params.id)
+    .single();
+
+  if (!user) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const newBanned = !user.is_banned;
+
+  const updates: Record<string, unknown> = { is_banned: newBanned };
+
+  // When banning: force-close all their sessions
+  if (newBanned) {
+    await supabase
+      .from("sessions")
+      .update({ is_active: false })
+      .eq("owner_id", params.id);
+  }
+
+  const { data, error } = await supabase
+    .from("users")
+    .update(updates)
+    .eq("id", params.id)
+    .select("id, is_banned")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data);
+}

--- a/app/api/sa/users/[id]/route.ts
+++ b/app/api/sa/users/[id]/route.ts
@@ -1,0 +1,121 @@
+// SUPERADMIN ONLY
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getSaTokenFromRequest, verifySaToken } from "@/lib/saAuth";
+import { hashPassword } from "@/lib/auth";
+
+async function auth(req: NextRequest) {
+  const token = await getSaTokenFromRequest(req);
+  return token && (await verifySaToken(token));
+}
+
+type ItemRow = { id: string; session_id: string; name: string; price: number; stock_quota: number | null };
+type OrderRow = { id: string; session_id: string; status: string; total_price: number };
+type PaymentRow = { id: string; session_id: string; payment_type: string; slots_purchased: number; amount_paid: number; payment_status: string; created_at: string };
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!(await auth(req))) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: user, error } = await supabase
+    .from("users")
+    .select("id, email, business_name, wa_number, role, is_banned, last_sign_in, created_at")
+    .eq("id", params.id)
+    .single();
+
+  if (error || !user) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { data: sessions } = await supabase
+    .from("sessions")
+    .select("id, title, slug, is_active, opens_at, closes_at, created_at")
+    .eq("owner_id", params.id)
+    .order("created_at", { ascending: false });
+
+  const sessionIds = (sessions || []).map((s: { id: string }) => s.id);
+
+  const [itemsRes, ordersRes, paymentsRes] = await Promise.all([
+    sessionIds.length
+      ? supabase.from("items").select("id, session_id, name, price, stock_quota").in("session_id", sessionIds)
+      : Promise.resolve({ data: [] as ItemRow[] }),
+    sessionIds.length
+      ? supabase.from("orders").select("id, session_id, status, total_price").in("session_id", sessionIds).neq("status", "deleted")
+      : Promise.resolve({ data: [] as OrderRow[] }),
+    supabase
+      .from("owner_payments")
+      .select("id, session_id, payment_type, slots_purchased, amount_paid, payment_status, created_at")
+      .eq("owner_id", params.id)
+      .order("created_at", { ascending: false }),
+  ]);
+
+  const itemsBySession: Record<string, ItemRow[]> = {};
+  for (const item of (itemsRes.data || []) as ItemRow[]) {
+    if (!itemsBySession[item.session_id]) itemsBySession[item.session_id] = [];
+    itemsBySession[item.session_id].push(item);
+  }
+
+  const ordersBySession: Record<string, OrderRow[]> = {};
+  for (const o of (ordersRes.data || []) as OrderRow[]) {
+    if (!ordersBySession[o.session_id]) ordersBySession[o.session_id] = [];
+    ordersBySession[o.session_id].push(o);
+  }
+
+  const sessionsWithStats = (sessions || []).map((s: { id: string; title: string; slug: string; is_active: boolean; opens_at: string | null; closes_at: string | null; created_at: string }) => {
+    const orders = ordersBySession[s.id] || [];
+    const approved = orders.filter((o) => o.status === "approved");
+    return {
+      ...s,
+      items: itemsBySession[s.id] || [],
+      order_count: orders.length,
+      approved_count: approved.length,
+      pending_count: orders.filter((o) => o.status === "pending").length,
+      estimated_revenue: approved.reduce((sum: number, o: OrderRow) => sum + (o.total_price || 0), 0),
+    };
+  });
+
+  const payments = (paymentsRes.data || []) as PaymentRow[];
+  const totalPaid = payments.filter((p) => p.payment_status === "paid").reduce((s: number, p) => s + p.amount_paid, 0);
+  const totalPending = payments.filter((p) => p.payment_status === "pending").reduce((s: number, p) => s + p.amount_paid, 0);
+  const totalSlots = payments.filter((p) => p.payment_status === "paid").reduce((s: number, p) => s + p.slots_purchased, 0);
+
+  return NextResponse.json({
+    user,
+    sessions: sessionsWithStats,
+    payments,
+    payment_stats: { totalPaid, totalPending, totalSlots },
+  });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!(await auth(req))) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const { business_name, whatsapp_number, role, new_password } = body;
+
+  const updates: Record<string, unknown> = {};
+  if (business_name !== undefined) updates.business_name = business_name;
+  if (whatsapp_number !== undefined) updates.wa_number = whatsapp_number;
+  if (role !== undefined) updates.role = role;
+  if (new_password) updates.password_hash = await hashPassword(new_password);
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("users")
+    .update(updates)
+    .eq("id", params.id)
+    .select("id, email, business_name, wa_number, role, is_banned")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data);
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!(await auth(req))) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  // ON DELETE CASCADE handles sessions → items → promos → orders → order_items → owner_payments
+  const { error } = await supabase.from("users").delete().eq("id", params.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/sa/users/route.ts
+++ b/app/api/sa/users/route.ts
@@ -1,0 +1,56 @@
+// SUPERADMIN ONLY
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getSaTokenFromRequest, verifySaToken } from "@/lib/saAuth";
+
+export async function GET(req: NextRequest) {
+  const token = await getSaTokenFromRequest(req);
+  if (!token || !(await verifySaToken(token))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: users, error } = await supabase
+    .from("users")
+    .select("id, email, business_name, wa_number, role, is_banned, last_sign_in, created_at")
+    .order("created_at", { ascending: false });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const userIds = (users || []).map((u: { id: string }) => u.id);
+
+  const [sessionsRes, paymentsRes] = await Promise.all([
+    supabase.from("sessions").select("id, owner_id").in("owner_id", userIds),
+    supabase.from("owner_payments").select("owner_id, slots_purchased, payment_status, amount_paid").in("owner_id", userIds),
+  ]);
+
+  const sessionsByOwner: Record<string, string[]> = {};
+  for (const s of (sessionsRes.data || []) as { id: string; owner_id: string }[]) {
+    if (!sessionsByOwner[s.owner_id]) sessionsByOwner[s.owner_id] = [];
+    sessionsByOwner[s.owner_id].push(s.id);
+  }
+
+  const allSessionIds = (sessionsRes.data || []).map((s: { id: string }) => s.id);
+  const ordersRes = allSessionIds.length
+    ? await supabase.from("orders").select("id, session_id").in("session_id", allSessionIds).neq("status", "deleted")
+    : { data: [] };
+
+  const ordersBySession: Record<string, number> = {};
+  for (const o of (ordersRes.data || []) as { session_id: string }[]) {
+    ordersBySession[o.session_id] = (ordersBySession[o.session_id] || 0) + 1;
+  }
+
+  type PaymentRow = { owner_id: string; payment_status: string; amount_paid: number; slots_purchased: number };
+  const allPayments = (paymentsRes.data || []) as PaymentRow[];
+
+  const result = (users || []).map((u: { id: string }) => {
+    const sessionIds = sessionsByOwner[u.id] || [];
+    const totalOrders = sessionIds.reduce((sum: number, sid: string) => sum + (ordersBySession[sid] || 0), 0);
+    const payments = allPayments.filter((p) => p.owner_id === u.id);
+    const totalPaid = payments
+      .filter((p) => p.payment_status === "paid")
+      .reduce((sum: number, p) => sum + (p.amount_paid || 0), 0);
+    return { ...u, total_sessions: sessionIds.length, total_orders: totalOrders, total_paid: totalPaid };
+  });
+
+  return NextResponse.json(result);
+}

--- a/app/api/sessions/[id]/orders/export/route.ts
+++ b/app/api/sessions/[id]/orders/export/route.ts
@@ -1,10 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { getAuthUserFromRequest } from "@/lib/auth";
-import { exportOrdersXlsx } from "@/lib/xlsx";
+import { exportOrdersXlsx, OrderExportRow } from "@/lib/xlsx";
 import { formatRp, formatDateTime } from "@/lib/format";
 
 const FREE_LIMIT = 7;
+
+interface OrderRow {
+  customer_name: string;
+  customer_wa: string;
+  customer_address: string;
+  total_price: number;
+  status: string;
+  created_at: string;
+  queue_number: number;
+  order_items: { items: { name: string } | null; quantity: number; unit_price: number }[];
+}
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   const user = await getAuthUserFromRequest(req);
@@ -18,15 +29,27 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     .single();
   if (!session) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  // Check paywall
-  const { data: payments } = await supabase
-    .from("owner_payments")
-    .select("slots_purchased")
-    .eq("session_id", params.id)
-    .eq("payment_status", "paid");
+  const { data: userRow } = await supabase
+    .from("users")
+    .select("role")
+    .eq("id", user.userId)
+    .single();
 
-  const paidSlots = (payments || []).reduce((sum, p) => sum + (p.slots_purchased || 0), 0);
-  const visibleLimit = FREE_LIMIT + paidSlots;
+  const isTester = userRow?.role === "tester";
+
+  let visibleLimit = Infinity;
+
+  if (!isTester) {
+    const { data: payments } = await supabase
+      .from("owner_payments")
+      .select("slots_purchased")
+      .eq("session_id", params.id)
+      .eq("payment_status", "paid");
+
+    const paidSlots = ((payments || []) as { slots_purchased: number }[])
+      .reduce((sum: number, p) => sum + (p.slots_purchased || 0), 0);
+    visibleLimit = FREE_LIMIT + paidSlots;
+  }
 
   const { data: orders, error } = await supabase
     .from("orders")
@@ -37,18 +60,17 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  if ((orders?.length || 0) > visibleLimit) {
+  if (!isTester && (orders?.length || 0) > visibleLimit) {
     return NextResponse.json({ error: "Export tidak tersedia selama ada pesanan tersembunyi" }, { status: 403 });
   }
 
-  const rows = (orders || []).map((o, idx) => ({
+  const rows: OrderExportRow[] = ((orders || []) as OrderRow[]).map((o, idx) => ({
     No: idx + 1,
     Nama: o.customer_name,
     "No WA": o.customer_wa,
     Alamat: o.customer_address,
     "Items": (o.order_items || [])
-      .map((oi: { items: { name: string }; quantity: number; unit_price: number }) =>
-        `${oi.items?.name} x${oi.quantity}`)
+      .map((oi) => `${oi.items?.name} x${oi.quantity}`)
       .join(", "),
     Total: formatRp(o.total_price),
     Status: o.status,

--- a/app/api/sessions/[id]/orders/route.ts
+++ b/app/api/sessions/[id]/orders/route.ts
@@ -16,15 +16,29 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     .single();
   if (!session) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  // Calculate visible limit
-  const { data: payments } = await supabase
-    .from("owner_payments")
-    .select("slots_purchased")
-    .eq("session_id", params.id)
-    .eq("payment_status", "paid");
+  const { data: userRow } = await supabase
+    .from("users")
+    .select("role")
+    .eq("id", user.userId)
+    .single();
 
-  const paidSlots = (payments || []).reduce((sum, p) => sum + (p.slots_purchased || 0), 0);
-  const visibleLimit = FREE_LIMIT + paidSlots;
+  const isTester = userRow?.role === "tester";
+
+  let visibleLimit: number;
+
+  if (isTester) {
+    visibleLimit = Infinity;
+  } else {
+    const { data: payments } = await supabase
+      .from("owner_payments")
+      .select("slots_purchased")
+      .eq("session_id", params.id)
+      .eq("payment_status", "paid");
+
+    const paidSlots = ((payments || []) as { slots_purchased: number }[])
+      .reduce((sum: number, p) => sum + (p.slots_purchased || 0), 0);
+    visibleLimit = FREE_LIMIT + paidSlots;
+  }
 
   const { data: orders, error } = await supabase
     .from("orders")
@@ -35,8 +49,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  const masked = (orders || []).map((order, idx) => {
-    if (idx < visibleLimit) return { ...order, blurred: false };
+  const masked = ((orders || []) as Record<string, unknown>[]).map((order, idx) => {
+    if (isTester || idx < visibleLimit) return { ...order, blurred: false };
     return {
       id: order.id,
       queue_number: order.queue_number,
@@ -46,5 +60,10 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     };
   });
 
-  return NextResponse.json({ orders: masked, visibleLimit, total: orders?.length || 0 });
+  return NextResponse.json({
+    orders: masked,
+    visibleLimit: isTester ? (orders?.length || 0) : visibleLimit,
+    total: orders?.length || 0,
+    isTester,
+  });
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,16 +1,25 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import toast from "react-hot-toast";
 import { useLang } from "@/lib/LanguageContext";
+import { Suspense } from "react";
 
-export default function LoginPage() {
+function LoginForm() {
   const { lang } = useLang();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const [bannedMsg, setBannedMsg] = useState("");
+
+  useEffect(() => {
+    if (searchParams.get("banned") === "1") {
+      setBannedMsg("Akun kamu dinonaktifkan. Hubungi kami untuk informasi lebih lanjut.");
+    }
+  }, [searchParams]);
 
   const handleLogin = async () => {
     if (!email || !password) {
@@ -46,6 +55,11 @@ export default function LoginPage() {
           <h1 className="font-semibold text-lg">{lang.login_title}</h1>
         </div>
         <div className="bg-white rounded-b-2xl shadow-sm px-6 py-6 space-y-4">
+          {bannedMsg && (
+            <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-xl px-4 py-3">
+              {bannedMsg}
+            </div>
+          )}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">{lang.login_email}</label>
             <input
@@ -84,5 +98,13 @@ export default function LoginPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/app/sa/(panel)/layout.tsx
+++ b/app/sa/(panel)/layout.tsx
@@ -1,0 +1,11 @@
+import SaSidebar from "@/components/sa/SaSidebar";
+
+export default function SaPanelLayout({ children }: { children: React.ReactNode }) {
+  const saPath = process.env.SUPERADMIN_PATH || "sa-panel-x7k2q";
+  return (
+    <div style={{ display: "flex", minHeight: "100vh" }}>
+      <SaSidebar saPath={saPath} />
+      <main style={{ flex: 1, overflowX: "hidden" }}>{children}</main>
+    </div>
+  );
+}

--- a/app/sa/(panel)/page.tsx
+++ b/app/sa/(panel)/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default function SaRootPage() {
+  const saPath = process.env.SUPERADMIN_PATH || "sa-panel-x7k2q";
+  redirect(`/${saPath}/users`);
+}

--- a/app/sa/(panel)/transactions/page.tsx
+++ b/app/sa/(panel)/transactions/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+import { useState, useEffect } from "react";
+
+const C = {
+  bg: "#0F1117",
+  surface: "#1A1D27",
+  border: "#2D3148",
+  accent: "#6C63FF",
+  text: "#E2E8F0",
+  muted: "#718096",
+  danger: "#FC8181",
+  success: "#68D391",
+};
+
+interface Transaction {
+  id: string;
+  payment_type: string;
+  slots_purchased: number;
+  amount_paid: number;
+  payment_status: string;
+  created_at: string;
+  owner_id: string;
+  session_id: string;
+  users: { business_name: string; wa_number: string } | null;
+  sessions: { title: string } | null;
+}
+interface Summary { total_revenue: number; total_pending: number; total_count: number }
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, { bg: string; color: string }> = {
+    paid: { bg: "rgba(104,211,145,0.15)", color: C.success },
+    pending: { bg: "rgba(246,224,94,0.15)", color: "#F6E05E" },
+    failed: { bg: "rgba(252,129,129,0.15)", color: C.danger },
+  };
+  const s = styles[status] || { bg: "rgba(113,128,150,0.15)", color: C.muted };
+  return (
+    <span style={{ ...s, borderRadius: "999px", padding: "0.125rem 0.625rem", fontSize: "0.75rem", fontWeight: 600 }}>
+      {status}
+    </span>
+  );
+}
+
+function formatDate(dt: string) {
+  return new Date(dt).toLocaleDateString("id-ID", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+function formatRp(n: number) { return "Rp " + n.toLocaleString("id-ID"); }
+
+const inputStyle = { background: C.surface, border: `1px solid ${C.border}`, borderRadius: "0.625rem", padding: "0.5rem 0.875rem", color: C.text, fontSize: "0.875rem", outline: "none" };
+
+export default function SaTransactionsPage() {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [summary, setSummary] = useState<Summary>({ total_revenue: 0, total_pending: 0, total_count: 0 });
+  const [loading, setLoading] = useState(true);
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  // Filters
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [packageFilter, setPackageFilter] = useState("all");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  useEffect(() => { fetchData(); }, []);
+
+  const fetchData = async () => {
+    setLoading(true);
+    const res = await fetch("/api/sa/transactions");
+    if (res.ok) {
+      const data = await res.json();
+      setTransactions(data.transactions || []);
+      setSummary(data.summary || { total_revenue: 0, total_pending: 0, total_count: 0 });
+    }
+    setLoading(false);
+  };
+
+  const handleApprove = async (id: string) => {
+    const res = await fetch(`/api/sa/transactions/${id}/approve`, { method: "PATCH" });
+    if (res.ok) {
+      setTransactions((prev) =>
+        prev.map((t) => {
+          if (t.id !== id) return t;
+          setSummary((s) => ({ ...s, total_revenue: s.total_revenue + t.amount_paid, total_pending: s.total_pending - t.amount_paid }));
+          return { ...t, payment_status: "paid" };
+        })
+      );
+    }
+  };
+
+  const handleBulkApprove = async () => {
+    setBulkLoading(true);
+    const res = await fetch("/api/sa/transactions/bulk-approve", { method: "POST" });
+    if (res.ok) await fetchData();
+    setBulkLoading(false);
+  };
+
+  const filtered = transactions.filter((t) => {
+    const q = search.toLowerCase();
+    const matchSearch = !q ||
+      (t.users?.business_name || "").toLowerCase().includes(q) ||
+      (t.users?.wa_number || "").includes(q);
+    const matchStatus = statusFilter === "all" || t.payment_status === statusFilter;
+    const matchPackage = packageFilter === "all" || t.payment_type === packageFilter;
+    const matchFrom = !dateFrom || new Date(t.created_at) >= new Date(dateFrom);
+    const matchTo = !dateTo || new Date(t.created_at) <= new Date(dateTo + "T23:59:59");
+    return matchSearch && matchStatus && matchPackage && matchFrom && matchTo;
+  });
+
+  const hasPending = filtered.some((t) => t.payment_status === "pending");
+
+  return (
+    <div style={{ padding: "2rem", color: C.text }}>
+      <h1 style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "1.5rem" }}>Transactions</h1>
+
+      {/* Summary Bar */}
+      <div style={{ display: "flex", gap: "1rem", marginBottom: "1.5rem", flexWrap: "wrap" }}>
+        {[
+          ["Total Revenue", formatRp(summary.total_revenue), C.success],
+          ["Total Pending", formatRp(summary.total_pending), "#F6E05E"],
+          ["Total Transactions", summary.total_count.toString(), C.accent],
+        ].map(([label, val, color]) => (
+          <div key={label as string} style={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: "0.875rem", padding: "1rem 1.5rem", minWidth: "160px" }}>
+            <div style={{ color: C.muted, fontSize: "0.75rem" }}>{label}</div>
+            <div style={{ color: color as string, fontWeight: 700, fontSize: "1.25rem", marginTop: "0.25rem" }}>{val}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Filters */}
+      <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1rem", flexWrap: "wrap" }}>
+        <input type="text" placeholder="Search by user name / WA…" value={search} onChange={(e) => setSearch(e.target.value)} style={{ ...inputStyle, flex: 1, minWidth: "200px" }} />
+        <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)} style={{ ...inputStyle, cursor: "pointer" }}>
+          <option value="all">All Status</option>
+          <option value="pending">Pending</option>
+          <option value="paid">Paid</option>
+          <option value="failed">Failed</option>
+        </select>
+        <select value={packageFilter} onChange={(e) => setPackageFilter(e.target.value)} style={{ ...inputStyle, cursor: "pointer" }}>
+          <option value="all">All Packages</option>
+          <option value="per_order">Per Order</option>
+          <option value="pack_100">Pack 100</option>
+        </select>
+        <input type="date" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)} style={{ ...inputStyle }} title="From date" />
+        <input type="date" value={dateTo} onChange={(e) => setDateTo(e.target.value)} style={{ ...inputStyle }} title="To date" />
+      </div>
+
+      {hasPending && (
+        <button
+          onClick={handleBulkApprove}
+          disabled={bulkLoading}
+          style={{ background: "rgba(104,211,145,0.15)", color: C.success, border: "none", borderRadius: "0.5rem", padding: "0.5rem 1rem", fontWeight: 600, cursor: "pointer", marginBottom: "1rem", fontSize: "0.875rem" }}
+        >
+          {bulkLoading ? "Approving…" : "Approve All Pending"}
+        </button>
+      )}
+
+      {/* Table */}
+      <div style={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: "0.875rem", overflow: "hidden" }}>
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem" }}>
+            <thead>
+              <tr style={{ background: "rgba(45,49,72,0.6)" }}>
+                {["Date", "User", "Session", "Package", "Slots", "Amount", "Status", "Actions"].map((h) => (
+                  <th key={h} style={{ padding: "0.875rem 1rem", textAlign: "left", color: C.muted, fontWeight: 600, fontSize: "0.8125rem", whiteSpace: "nowrap", background: "rgba(26,29,39,0.95)" }}>
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr><td colSpan={8} style={{ padding: "3rem", textAlign: "center", color: C.muted }}>Loading…</td></tr>
+              ) : filtered.length === 0 ? (
+                <tr><td colSpan={8} style={{ padding: "3rem", textAlign: "center", color: C.muted }}>No transactions found</td></tr>
+              ) : (
+                filtered.map((t, idx) => (
+                  <tr key={t.id} style={{ background: idx % 2 === 0 ? "transparent" : "rgba(45,49,72,0.25)", borderTop: `1px solid ${C.border}` }}>
+                    <td style={{ padding: "0.75rem 1rem", color: C.muted, fontSize: "0.8125rem", whiteSpace: "nowrap" }}>{formatDate(t.created_at)}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}>
+                      <div style={{ fontWeight: 500 }}>{t.users?.business_name || "—"}</div>
+                      <div style={{ color: C.muted, fontSize: "0.75rem" }}>{t.users?.wa_number || ""}</div>
+                    </td>
+                    <td style={{ padding: "0.75rem 1rem", color: C.muted, fontSize: "0.8125rem" }}>{t.sessions?.title || "—"}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}>{t.payment_type}</td>
+                    <td style={{ padding: "0.75rem 1rem", textAlign: "center" }}>{t.slots_purchased}</td>
+                    <td style={{ padding: "0.75rem 1rem", whiteSpace: "nowrap" }}>{formatRp(t.amount_paid)}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}><StatusBadge status={t.payment_status} /></td>
+                    <td style={{ padding: "0.75rem 1rem" }}>
+                      {t.payment_status === "pending" && (
+                        <button
+                          onClick={() => handleApprove(t.id)}
+                          style={{ background: "rgba(104,211,145,0.15)", color: C.success, border: "none", borderRadius: "0.5rem", padding: "0.25rem 0.625rem", fontWeight: 600, cursor: "pointer", fontSize: "0.8125rem" }}
+                        >
+                          Approve
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/sa/(panel)/users/[userId]/page.tsx
+++ b/app/sa/(panel)/users/[userId]/page.tsx
@@ -1,0 +1,511 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+
+const C = {
+  bg: "#0F1117",
+  surface: "#1A1D27",
+  border: "#2D3148",
+  accent: "#6C63FF",
+  text: "#E2E8F0",
+  muted: "#718096",
+  danger: "#FC8181",
+  success: "#68D391",
+};
+
+interface UserDetail {
+  id: string;
+  email: string;
+  business_name: string;
+  wa_number: string;
+  role: string;
+  is_banned: boolean;
+  last_sign_in: string | null;
+  created_at: string;
+}
+interface Payment {
+  id: string;
+  session_id: string;
+  payment_type: string;
+  slots_purchased: number;
+  amount_paid: number;
+  payment_status: string;
+  created_at: string;
+}
+interface SessionData {
+  id: string;
+  title: string;
+  slug: string;
+  is_active: boolean;
+  opens_at: string | null;
+  closes_at: string | null;
+  created_at: string;
+  items: { id: string; name: string; price: number; stock_quota: number | null }[];
+  order_count: number;
+  approved_count: number;
+  pending_count: number;
+  estimated_revenue: number;
+}
+interface PaymentStats { totalPaid: number; totalPending: number; totalSlots: number }
+
+function formatDate(dt: string | null) {
+  if (!dt) return "—";
+  return new Date(dt).toLocaleDateString("id-ID", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+function formatRp(n: number) {
+  return "Rp " + n.toLocaleString("id-ID");
+}
+
+function RoleBadge({ role }: { role: string }) {
+  return (
+    <span style={{ background: role === "tester" ? "rgba(108,99,255,0.15)" : "rgba(113,128,150,0.15)", color: role === "tester" ? C.accent : C.muted, border: `1px solid ${role === "tester" ? "rgba(108,99,255,0.4)" : "rgba(113,128,150,0.3)"}`, borderRadius: "999px", padding: "0.125rem 0.625rem", fontSize: "0.75rem", fontWeight: 600 }}>
+      {role}
+    </span>
+  );
+}
+function StatusBadge({ value, options }: { value: string; options: Record<string, { bg: string; color: string }> }) {
+  const s = options[value] || { bg: "rgba(113,128,150,0.15)", color: C.muted };
+  return <span style={{ ...s, borderRadius: "999px", padding: "0.125rem 0.625rem", fontSize: "0.75rem", fontWeight: 600 }}>{value}</span>;
+}
+
+const paymentStatusOptions: Record<string, { bg: string; color: string }> = {
+  paid: { bg: "rgba(104,211,145,0.15)", color: C.success },
+  pending: { bg: "rgba(255,193,7,0.15)", color: "#F6E05E" },
+  failed: { bg: "rgba(252,129,129,0.15)", color: C.danger },
+};
+
+const inputStyle = { background: C.bg, border: `1px solid ${C.border}`, borderRadius: "0.625rem", padding: "0.5rem 0.875rem", color: C.text, fontSize: "0.875rem", outline: "none", width: "100%" };
+const labelStyle = { color: C.muted, fontSize: "0.8125rem", fontWeight: 500, display: "block", marginBottom: "0.375rem" };
+
+export default function SaUserDetailPage() {
+  const { userId } = useParams<{ userId: string }>();
+  const router = useRouter();
+  const [saPath, setSaPath] = useState("");
+  const [user, setUser] = useState<UserDetail | null>(null);
+  const [sessions, setSessions] = useState<SessionData[]>([]);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [payStats, setPayStats] = useState<PaymentStats>({ totalPaid: 0, totalPending: 0, totalSlots: 0 });
+  const [loading, setLoading] = useState(true);
+
+  // Edit modal
+  const [showEdit, setShowEdit] = useState(false);
+  const [editForm, setEditForm] = useState({ business_name: "", whatsapp_number: "", role: "personal", new_password: "", confirm_password: "" });
+  const [editLoading, setEditLoading] = useState(false);
+  const [editError, setEditError] = useState("");
+
+  // Expanded sessions
+  const [expandedSessions, setExpandedSessions] = useState<Set<string>>(new Set());
+
+  // Delete / ban modals
+  const [showBan, setShowBan] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+  const [deleteConfirmWa, setDeleteConfirmWa] = useState("");
+  const [actionLoading, setActionLoading] = useState(false);
+
+  useEffect(() => {
+    const parts = window.location.pathname.split("/");
+    setSaPath(parts[1] || "");
+    fetchData();
+  }, [userId]);
+
+  const fetchData = async () => {
+    setLoading(true);
+    const res = await fetch(`/api/sa/users/${userId}`);
+    if (!res.ok) { router.back(); return; }
+    const data = await res.json();
+    setUser(data.user);
+    setSessions(data.sessions || []);
+    setPayments(data.payments || []);
+    setPayStats(data.payment_stats || { totalPaid: 0, totalPending: 0, totalSlots: 0 });
+    setEditForm({
+      business_name: data.user.business_name,
+      whatsapp_number: data.user.wa_number,
+      role: data.user.role,
+      new_password: "",
+      confirm_password: "",
+    });
+    setLoading(false);
+  };
+
+  const handleSaveEdit = async () => {
+    setEditError("");
+    if (editForm.new_password && editForm.new_password !== editForm.confirm_password) {
+      setEditError("Passwords do not match");
+      return;
+    }
+    setEditLoading(true);
+    const body: Record<string, string> = {
+      business_name: editForm.business_name,
+      whatsapp_number: editForm.whatsapp_number,
+      role: editForm.role,
+    };
+    if (editForm.new_password) body.new_password = editForm.new_password;
+    const res = await fetch(`/api/sa/users/${userId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    setEditLoading(false);
+    if (res.ok) {
+      const updated = await res.json();
+      setUser((u) => u ? { ...u, ...updated } : u);
+      setShowEdit(false);
+    } else {
+      const d = await res.json();
+      setEditError(d.error || "Failed to save");
+    }
+  };
+
+  const handleApprovePayment = async (paymentId: string) => {
+    const res = await fetch(`/api/sa/transactions/${paymentId}/approve`, { method: "PATCH" });
+    if (res.ok) {
+      setPayments((prev) => prev.map((p) => p.id === paymentId ? { ...p, payment_status: "paid" } : p));
+      setPayStats((s) => {
+        const p = payments.find((x) => x.id === paymentId);
+        if (!p) return s;
+        return { ...s, totalPaid: s.totalPaid + p.amount_paid, totalPending: s.totalPending - p.amount_paid, totalSlots: s.totalSlots + p.slots_purchased };
+      });
+    }
+  };
+
+  const handleBulkApprovePayments = async () => {
+    const pending = payments.filter((p) => p.payment_status === "pending");
+    await Promise.all(pending.map((p) => handleApprovePayment(p.id)));
+  };
+
+  const handleBan = async () => {
+    if (!user) return;
+    setActionLoading(true);
+    const res = await fetch(`/api/sa/users/${userId}/ban`, { method: "PATCH" });
+    if (res.ok) {
+      const updated = await res.json();
+      setUser((u) => u ? { ...u, is_banned: updated.is_banned } : u);
+    }
+    setActionLoading(false);
+    setShowBan(false);
+  };
+
+  const handleDelete = async () => {
+    if (!user || deleteConfirmWa !== user.wa_number) return;
+    setActionLoading(true);
+    const res = await fetch(`/api/sa/users/${userId}`, { method: "DELETE" });
+    if (res.ok) router.push(`/${saPath}/users`);
+    setActionLoading(false);
+  };
+
+  if (loading) {
+    return (
+      <div style={{ padding: "2rem", color: C.muted, display: "flex", alignItems: "center", justifyContent: "center", minHeight: "60vh" }}>
+        Loading…
+      </div>
+    );
+  }
+  if (!user) return null;
+
+  const sectionCard = (children: React.ReactNode) => (
+    <div style={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: "0.875rem", padding: "1.5rem", marginBottom: "1.5rem" }}>
+      {children}
+    </div>
+  );
+
+  const sectionTitle = (title: string) => (
+    <h2 style={{ fontSize: "1.0625rem", fontWeight: 700, color: C.text, marginBottom: "1.25rem", paddingBottom: "0.75rem", borderBottom: `1px solid ${C.border}` }}>
+      {title}
+    </h2>
+  );
+
+  return (
+    <div style={{ padding: "2rem", color: C.text, maxWidth: "900px" }}>
+      {/* Back */}
+      <Link href={`/${saPath}/users`} style={{ color: C.muted, textDecoration: "none", fontSize: "0.875rem", display: "inline-flex", alignItems: "center", gap: "0.375rem", marginBottom: "1.25rem" }}>
+        ← Back to Users
+      </Link>
+
+      <h1 style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "1.5rem" }}>{user.business_name}</h1>
+
+      {/* ── 1. Profile Card ───────────────────────────────────────────── */}
+      {sectionCard(
+        <>
+          {sectionTitle("Profile")}
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: "1rem", marginBottom: "1.25rem" }}>
+            {[
+              ["Business Name", user.business_name],
+              ["Email", user.email],
+              ["WA Number", user.wa_number],
+              ["Created At", formatDate(user.created_at)],
+              ["Last Sign In", formatDate(user.last_sign_in)],
+            ].map(([k, v]) => (
+              <div key={k}>
+                <div style={{ color: C.muted, fontSize: "0.75rem", marginBottom: "0.25rem" }}>{k}</div>
+                <div style={{ fontWeight: 500 }}>{v}</div>
+              </div>
+            ))}
+            <div>
+              <div style={{ color: C.muted, fontSize: "0.75rem", marginBottom: "0.25rem" }}>Role</div>
+              <RoleBadge role={user.role} />
+            </div>
+            <div>
+              <div style={{ color: C.muted, fontSize: "0.75rem", marginBottom: "0.25rem" }}>Status</div>
+              <StatusBadge value={user.is_banned ? "Banned" : "Active"} options={{ Active: { bg: "rgba(104,211,145,0.15)", color: C.success }, Banned: { bg: "rgba(252,129,129,0.15)", color: C.danger } }} />
+            </div>
+          </div>
+          <button
+            onClick={() => setShowEdit(true)}
+            style={{ background: "rgba(108,99,255,0.15)", color: C.accent, border: "none", borderRadius: "0.5rem", padding: "0.5rem 1rem", fontWeight: 600, cursor: "pointer", fontSize: "0.875rem" }}
+          >
+            Edit Profile
+          </button>
+        </>
+      )}
+
+      {/* ── 2. Payment History ────────────────────────────────────────── */}
+      {sectionCard(
+        <>
+          {sectionTitle("Payment History")}
+          <div style={{ display: "flex", gap: "1rem", marginBottom: "1.25rem", flexWrap: "wrap" }}>
+            {[
+              ["Total Paid", formatRp(payStats.totalPaid), C.success],
+              ["Total Pending", formatRp(payStats.totalPending), "#F6E05E"],
+              ["Slots Unlocked", payStats.totalSlots.toString(), C.accent],
+            ].map(([label, val, color]) => (
+              <div key={label as string} style={{ background: C.bg, border: `1px solid ${C.border}`, borderRadius: "0.75rem", padding: "1rem 1.25rem", minWidth: "140px" }}>
+                <div style={{ color: C.muted, fontSize: "0.75rem" }}>{label}</div>
+                <div style={{ color: color as string, fontWeight: 700, fontSize: "1.125rem", marginTop: "0.25rem" }}>{val}</div>
+              </div>
+            ))}
+          </div>
+          {payments.some((p) => p.payment_status === "pending") && (
+            <button
+              onClick={handleBulkApprovePayments}
+              style={{ background: "rgba(104,211,145,0.15)", color: C.success, border: "none", borderRadius: "0.5rem", padding: "0.5rem 1rem", fontWeight: 600, cursor: "pointer", fontSize: "0.875rem", marginBottom: "1rem" }}
+            >
+              Approve All Pending
+            </button>
+          )}
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem" }}>
+              <thead>
+                <tr style={{ background: "rgba(45,49,72,0.4)" }}>
+                  {["Date", "Package", "Slots", "Amount", "Status", "Actions"].map((h) => (
+                    <th key={h} style={{ padding: "0.75rem 1rem", textAlign: "left", color: C.muted, fontWeight: 600, fontSize: "0.8125rem" }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {payments.length === 0 ? (
+                  <tr><td colSpan={6} style={{ padding: "2rem", textAlign: "center", color: C.muted }}>No payments</td></tr>
+                ) : payments.map((p, idx) => (
+                  <tr key={p.id} style={{ background: idx % 2 === 0 ? "transparent" : "rgba(45,49,72,0.2)", borderTop: `1px solid ${C.border}` }}>
+                    <td style={{ padding: "0.75rem 1rem", color: C.muted, fontSize: "0.8125rem" }}>{formatDate(p.created_at)}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}>{p.payment_type}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}>{p.slots_purchased}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}>{formatRp(p.amount_paid)}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}><StatusBadge value={p.payment_status} options={paymentStatusOptions} /></td>
+                    <td style={{ padding: "0.75rem 1rem" }}>
+                      {p.payment_status === "pending" && (
+                        <button onClick={() => handleApprovePayment(p.id)} style={{ background: "rgba(104,211,145,0.15)", color: C.success, border: "none", borderRadius: "0.5rem", padding: "0.25rem 0.625rem", fontWeight: 600, cursor: "pointer", fontSize: "0.8125rem" }}>
+                          Approve
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      {/* ── 3. Sessions ───────────────────────────────────────────────── */}
+      {sectionCard(
+        <>
+          {sectionTitle(`Sessions (${sessions.length})`)}
+          {sessions.length === 0 ? (
+            <p style={{ color: C.muted }}>No sessions</p>
+          ) : (
+            sessions.map((s) => {
+              const expanded = expandedSessions.has(s.id);
+              return (
+                <div key={s.id} style={{ border: `1px solid ${C.border}`, borderRadius: "0.75rem", marginBottom: "0.75rem", overflow: "hidden" }}>
+                  <button
+                    onClick={() => setExpandedSessions((prev) => {
+                      const n = new Set(prev);
+                      expanded ? n.delete(s.id) : n.add(s.id);
+                      return n;
+                    })}
+                    style={{ width: "100%", background: "rgba(45,49,72,0.3)", border: "none", padding: "1rem", display: "flex", alignItems: "center", justifyContent: "space-between", cursor: "pointer", color: C.text }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+                      <span style={{ fontWeight: 600 }}>{s.title}</span>
+                      <span style={{ color: C.muted, fontSize: "0.8125rem" }}>/{s.slug}</span>
+                      <StatusBadge value={s.is_active ? "open" : "closed"} options={{ open: { bg: "rgba(104,211,145,0.15)", color: C.success }, closed: { bg: "rgba(113,128,150,0.15)", color: C.muted } }} />
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+                      <span style={{ color: C.muted, fontSize: "0.8125rem" }}>{s.order_count} orders</span>
+                      <span style={{ color: C.muted }}>{expanded ? "▲" : "▼"}</span>
+                    </div>
+                  </button>
+                  {expanded && (
+                    <div style={{ padding: "1rem", background: C.surface }}>
+                      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))", gap: "0.75rem", marginBottom: "1rem" }}>
+                        {[
+                          ["Created", formatDate(s.created_at)],
+                          ["Opens At", formatDate(s.opens_at)],
+                          ["Closes At", formatDate(s.closes_at)],
+                          ["Total Orders", s.order_count],
+                          ["Approved", s.approved_count],
+                          ["Pending", s.pending_count],
+                          ["Est. Revenue", formatRp(s.estimated_revenue)],
+                        ].map(([k, v]) => (
+                          <div key={k as string}>
+                            <div style={{ color: C.muted, fontSize: "0.75rem" }}>{k}</div>
+                            <div style={{ fontWeight: 500, fontSize: "0.875rem" }}>{v as string | number}</div>
+                          </div>
+                        ))}
+                      </div>
+                      {s.items.length > 0 && (
+                        <>
+                          <div style={{ color: C.muted, fontSize: "0.8125rem", marginBottom: "0.5rem" }}>Items</div>
+                          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.8125rem" }}>
+                            <thead>
+                              <tr style={{ background: "rgba(45,49,72,0.4)" }}>
+                                {["Name", "Price", "Quota"].map((h) => (
+                                  <th key={h} style={{ padding: "0.5rem 0.75rem", textAlign: "left", color: C.muted, fontWeight: 600 }}>{h}</th>
+                                ))}
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {s.items.map((item) => (
+                                <tr key={item.id} style={{ borderTop: `1px solid ${C.border}` }}>
+                                  <td style={{ padding: "0.5rem 0.75rem" }}>{item.name}</td>
+                                  <td style={{ padding: "0.5rem 0.75rem" }}>{formatRp(item.price)}</td>
+                                  <td style={{ padding: "0.5rem 0.75rem", color: C.muted }}>{item.stock_quota ?? "—"}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </>
+                      )}
+                      <a
+                        href={`/p/${s.slug}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ display: "inline-block", marginTop: "0.75rem", color: C.accent, fontSize: "0.8125rem", textDecoration: "none" }}
+                      >
+                        View public page ↗
+                      </a>
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </>
+      )}
+
+      {/* ── 4. Danger Zone ────────────────────────────────────────────── */}
+      <div style={{ background: C.surface, border: `1px solid ${C.danger}`, borderRadius: "0.875rem", padding: "1.5rem" }}>
+        {sectionTitle("Account Actions")}
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+          <button
+            onClick={() => setShowBan(true)}
+            style={{ background: user.is_banned ? "rgba(104,211,145,0.15)" : "rgba(252,129,129,0.15)", color: user.is_banned ? C.success : C.danger, border: "none", borderRadius: "0.5rem", padding: "0.625rem 1.25rem", fontWeight: 600, cursor: "pointer" }}
+          >
+            {user.is_banned ? "Unban User" : "Ban User"}
+          </button>
+          <button
+            onClick={() => { setShowDelete(true); setDeleteConfirmWa(""); }}
+            style={{ background: "rgba(252,129,129,0.15)", color: C.danger, border: "none", borderRadius: "0.5rem", padding: "0.625rem 1.25rem", fontWeight: 600, cursor: "pointer" }}
+          >
+            Delete Account
+          </button>
+        </div>
+      </div>
+
+      {/* ── Edit Modal ───────────────────────────────────────────────── */}
+      {showEdit && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.75)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50, padding: "1rem" }}>
+          <div style={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: "1rem", padding: "1.5rem", maxWidth: "440px", width: "100%", maxHeight: "90vh", overflowY: "auto" }}>
+            <h3 style={{ fontWeight: 700, marginBottom: "1.25rem", color: C.text }}>Edit User</h3>
+            <div style={{ marginBottom: "1rem" }}>
+              <label style={labelStyle}>Business Name</label>
+              <input style={inputStyle} value={editForm.business_name} onChange={(e) => setEditForm((f) => ({ ...f, business_name: e.target.value }))} />
+            </div>
+            <div style={{ marginBottom: "1rem" }}>
+              <label style={labelStyle}>WA Number</label>
+              <input style={inputStyle} value={editForm.whatsapp_number} onChange={(e) => setEditForm((f) => ({ ...f, whatsapp_number: e.target.value }))} />
+            </div>
+            <div style={{ marginBottom: "1rem" }}>
+              <label style={labelStyle}>Role</label>
+              <select style={{ ...inputStyle, cursor: "pointer" }} value={editForm.role} onChange={(e) => setEditForm((f) => ({ ...f, role: e.target.value }))}>
+                <option value="personal">personal</option>
+                <option value="tester">tester</option>
+              </select>
+            </div>
+            <div style={{ borderTop: `1px solid ${C.border}`, paddingTop: "1rem", marginTop: "1rem", marginBottom: "1rem" }}>
+              <div style={{ color: C.muted, fontSize: "0.8125rem", marginBottom: "0.75rem" }}>Reset Password (leave blank to keep current)</div>
+              <div style={{ marginBottom: "0.75rem" }}>
+                <label style={labelStyle}>New Password</label>
+                <input type="password" style={inputStyle} value={editForm.new_password} onChange={(e) => setEditForm((f) => ({ ...f, new_password: e.target.value }))} />
+              </div>
+              <div>
+                <label style={labelStyle}>Confirm Password</label>
+                <input type="password" style={inputStyle} value={editForm.confirm_password} onChange={(e) => setEditForm((f) => ({ ...f, confirm_password: e.target.value }))} />
+              </div>
+            </div>
+            {editError && <div style={{ color: C.danger, fontSize: "0.875rem", marginBottom: "0.75rem" }}>{editError}</div>}
+            <div style={{ display: "flex", gap: "0.75rem" }}>
+              <button onClick={() => setShowEdit(false)} style={{ flex: 1, background: "rgba(113,128,150,0.15)", color: C.muted, border: "none", borderRadius: "0.5rem", padding: "0.625rem", fontWeight: 600, cursor: "pointer" }}>
+                Cancel
+              </button>
+              <button onClick={handleSaveEdit} disabled={editLoading} style={{ flex: 1, background: C.accent, color: "#fff", border: "none", borderRadius: "0.5rem", padding: "0.625rem", fontWeight: 600, cursor: editLoading ? "not-allowed" : "pointer" }}>
+                {editLoading ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Ban Modal ────────────────────────────────────────────────── */}
+      {showBan && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.75)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50, padding: "1rem" }}>
+          <div style={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: "1rem", padding: "1.5rem", maxWidth: "400px", width: "100%" }}>
+            <h3 style={{ fontWeight: 700, marginBottom: "0.75rem", color: C.text }}>{user.is_banned ? "Unban" : "Ban"} User</h3>
+            <p style={{ color: C.muted, marginBottom: "1.25rem" }}>
+              {user.is_banned ? "Restore access for this user?" : "Ban this user? All their sessions will be deactivated and they cannot log in."}
+            </p>
+            <div style={{ display: "flex", gap: "0.75rem" }}>
+              <button onClick={() => setShowBan(false)} style={{ flex: 1, background: "rgba(113,128,150,0.15)", color: C.muted, border: "none", borderRadius: "0.5rem", padding: "0.625rem", fontWeight: 600, cursor: "pointer" }}>Cancel</button>
+              <button onClick={handleBan} disabled={actionLoading} style={{ flex: 1, background: user.is_banned ? "rgba(104,211,145,0.2)" : "rgba(252,129,129,0.2)", color: user.is_banned ? C.success : C.danger, border: "none", borderRadius: "0.5rem", padding: "0.625rem", fontWeight: 600, cursor: "pointer" }}>
+                {actionLoading ? "…" : user.is_banned ? "Unban" : "Ban"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Delete Modal ─────────────────────────────────────────────── */}
+      {showDelete && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.75)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50, padding: "1rem" }}>
+          <div style={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: "1rem", padding: "1.5rem", maxWidth: "440px", width: "100%" }}>
+            <h3 style={{ fontWeight: 700, marginBottom: "0.75rem", color: C.danger }}>Delete Account — Permanent</h3>
+            <p style={{ color: C.muted, marginBottom: "0.75rem" }}>
+              Permanently delete <strong style={{ color: C.text }}>{user.business_name}</strong> and ALL their data. This cannot be undone.
+            </p>
+            <p style={{ color: C.text, fontSize: "0.875rem", marginBottom: "0.5rem" }}>
+              Type WA number <strong>{user.wa_number}</strong> to confirm:
+            </p>
+            <input type="text" value={deleteConfirmWa} onChange={(e) => setDeleteConfirmWa(e.target.value)} placeholder={user.wa_number} style={{ ...inputStyle, marginBottom: "1rem" }} />
+            <div style={{ display: "flex", gap: "0.75rem" }}>
+              <button onClick={() => setShowDelete(false)} style={{ flex: 1, background: "rgba(113,128,150,0.15)", color: C.muted, border: "none", borderRadius: "0.5rem", padding: "0.625rem", fontWeight: 600, cursor: "pointer" }}>Cancel</button>
+              <button onClick={handleDelete} disabled={deleteConfirmWa !== user.wa_number || actionLoading} style={{ flex: 1, background: "rgba(252,129,129,0.2)", color: C.danger, border: "none", borderRadius: "0.5rem", padding: "0.625rem", fontWeight: 600, cursor: "pointer", opacity: deleteConfirmWa !== user.wa_number ? 0.5 : 1 }}>
+                {actionLoading ? "Deleting…" : "Delete Forever"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/sa/(panel)/users/page.tsx
+++ b/app/sa/(panel)/users/page.tsx
@@ -1,0 +1,381 @@
+"use client";
+import { useState, useEffect } from "react";
+import Link from "next/link";
+
+interface SAUser {
+  id: string;
+  email: string;
+  business_name: string;
+  wa_number: string;
+  role: string;
+  is_banned: boolean;
+  last_sign_in: string | null;
+  created_at: string;
+  total_sessions: number;
+  total_orders: number;
+  total_paid: number;
+}
+
+const SA_COLORS = {
+  bg: "#0F1117",
+  surface: "#1A1D27",
+  border: "#2D3148",
+  accent: "#6C63FF",
+  text: "#E2E8F0",
+  muted: "#718096",
+  danger: "#FC8181",
+  success: "#68D391",
+};
+
+function RoleBadge({ role }: { role: string }) {
+  const color = role === "tester" ? SA_COLORS.accent : SA_COLORS.muted;
+  return (
+    <span
+      style={{
+        background: role === "tester" ? "rgba(108,99,255,0.15)" : "rgba(113,128,150,0.15)",
+        color,
+        border: `1px solid ${role === "tester" ? "rgba(108,99,255,0.4)" : "rgba(113,128,150,0.3)"}`,
+        borderRadius: "999px",
+        padding: "0.125rem 0.625rem",
+        fontSize: "0.75rem",
+        fontWeight: 600,
+        textTransform: "uppercase",
+      }}
+    >
+      {role}
+    </span>
+  );
+}
+
+function StatusBadge({ banned }: { banned: boolean }) {
+  return (
+    <span
+      style={{
+        background: banned ? "rgba(252,129,129,0.15)" : "rgba(104,211,145,0.15)",
+        color: banned ? SA_COLORS.danger : SA_COLORS.success,
+        border: `1px solid ${banned ? "rgba(252,129,129,0.3)" : "rgba(104,211,145,0.3)"}`,
+        borderRadius: "999px",
+        padding: "0.125rem 0.625rem",
+        fontSize: "0.75rem",
+        fontWeight: 600,
+      }}
+    >
+      {banned ? "Banned" : "Active"}
+    </span>
+  );
+}
+
+function formatDate(dt: string | null) {
+  if (!dt) return "—";
+  return new Date(dt).toLocaleDateString("id-ID", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+export default function SaUsersPage() {
+  const [users, setUsers] = useState<SAUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+
+  // Modals
+  const [banTarget, setBanTarget] = useState<SAUser | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<SAUser | null>(null);
+  const [deleteConfirmWa, setDeleteConfirmWa] = useState("");
+  const [actionLoading, setActionLoading] = useState(false);
+
+  const [saPath, setSaPath] = useState("");
+
+  useEffect(() => {
+    const parts = window.location.pathname.split("/");
+    setSaPath(parts[1] || "");
+    fetchUsers();
+  }, []);
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    const res = await fetch("/api/sa/users");
+    if (res.ok) setUsers(await res.json());
+    setLoading(false);
+  };
+
+  const filtered = users.filter((u) => {
+    const q = search.toLowerCase();
+    const matchSearch = !q || u.business_name.toLowerCase().includes(q) || u.wa_number.includes(q) || u.email.toLowerCase().includes(q);
+    const matchRole = roleFilter === "all" || u.role === roleFilter;
+    const matchStatus = statusFilter === "all" || (statusFilter === "banned" ? u.is_banned : !u.is_banned);
+    return matchSearch && matchRole && matchStatus;
+  });
+
+  const handleBan = async () => {
+    if (!banTarget) return;
+    setActionLoading(true);
+    const res = await fetch(`/api/sa/users/${banTarget.id}/ban`, { method: "PATCH" });
+    if (res.ok) {
+      const updated = await res.json();
+      setUsers((prev) => prev.map((u) => (u.id === updated.id ? { ...u, is_banned: updated.is_banned } : u)));
+    }
+    setActionLoading(false);
+    setBanTarget(null);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget || deleteConfirmWa !== deleteTarget.wa_number) return;
+    setActionLoading(true);
+    const res = await fetch(`/api/sa/users/${deleteTarget.id}`, { method: "DELETE" });
+    if (res.ok) {
+      setUsers((prev) => prev.filter((u) => u.id !== deleteTarget.id));
+    }
+    setActionLoading(false);
+    setDeleteTarget(null);
+    setDeleteConfirmWa("");
+  };
+
+  const inputStyle = {
+    background: SA_COLORS.surface,
+    border: `1px solid ${SA_COLORS.border}`,
+    borderRadius: "0.625rem",
+    padding: "0.5rem 0.875rem",
+    color: SA_COLORS.text,
+    fontSize: "0.875rem",
+    outline: "none",
+  };
+
+  const btnStyle = (variant: "primary" | "danger" | "ghost") => ({
+    border: "none",
+    borderRadius: "0.5rem",
+    padding: "0.375rem 0.75rem",
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    cursor: "pointer",
+    ...(variant === "primary"
+      ? { background: "rgba(108,99,255,0.2)", color: SA_COLORS.accent }
+      : variant === "danger"
+      ? { background: "rgba(252,129,129,0.15)", color: SA_COLORS.danger }
+      : { background: "rgba(113,128,150,0.15)", color: SA_COLORS.muted }),
+  });
+
+  return (
+    <div style={{ padding: "2rem", color: SA_COLORS.text }}>
+      <h1 style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "1.5rem" }}>Users</h1>
+
+      {/* Filters */}
+      <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1.25rem", flexWrap: "wrap" }}>
+        <input
+          type="text"
+          placeholder="Search by name, WA, or email…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ ...inputStyle, minWidth: "220px", flex: 1 }}
+        />
+        <select
+          value={roleFilter}
+          onChange={(e) => setRoleFilter(e.target.value)}
+          style={{ ...inputStyle, cursor: "pointer" }}
+        >
+          <option value="all">All Roles</option>
+          <option value="personal">Personal</option>
+          <option value="tester">Tester</option>
+        </select>
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          style={{ ...inputStyle, cursor: "pointer" }}
+        >
+          <option value="all">All Status</option>
+          <option value="active">Active</option>
+          <option value="banned">Banned</option>
+        </select>
+      </div>
+
+      {/* Table */}
+      <div
+        style={{
+          background: SA_COLORS.surface,
+          border: `1px solid ${SA_COLORS.border}`,
+          borderRadius: "0.875rem",
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem" }}>
+            <thead>
+              <tr style={{ background: "rgba(45,49,72,0.6)" }}>
+                {["Business Name", "WA Number", "Role", "Status", "Last Sign In", "Sessions", "Orders", "Actions"].map((h) => (
+                  <th
+                    key={h}
+                    style={{
+                      padding: "0.875rem 1rem",
+                      textAlign: "left",
+                      color: SA_COLORS.muted,
+                      fontWeight: 600,
+                      fontSize: "0.8125rem",
+                      whiteSpace: "nowrap",
+                      position: "sticky",
+                      top: 0,
+                      background: "rgba(26,29,39,0.95)",
+                    }}
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={8} style={{ padding: "3rem", textAlign: "center", color: SA_COLORS.muted }}>
+                    Loading…
+                  </td>
+                </tr>
+              ) : filtered.length === 0 ? (
+                <tr>
+                  <td colSpan={8} style={{ padding: "3rem", textAlign: "center", color: SA_COLORS.muted }}>
+                    No users found
+                  </td>
+                </tr>
+              ) : (
+                filtered.map((u, idx) => (
+                  <tr
+                    key={u.id}
+                    style={{
+                      background: idx % 2 === 0 ? "transparent" : "rgba(45,49,72,0.25)",
+                      borderTop: `1px solid ${SA_COLORS.border}`,
+                    }}
+                  >
+                    <td style={{ padding: "0.75rem 1rem", fontWeight: 500 }}>
+                      <div>{u.business_name}</div>
+                      <div style={{ color: SA_COLORS.muted, fontSize: "0.75rem" }}>{u.email}</div>
+                    </td>
+                    <td style={{ padding: "0.75rem 1rem", color: SA_COLORS.muted }}>{u.wa_number}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}>
+                      <RoleBadge role={u.role} />
+                    </td>
+                    <td style={{ padding: "0.75rem 1rem" }}>
+                      <StatusBadge banned={u.is_banned} />
+                    </td>
+                    <td style={{ padding: "0.75rem 1rem", color: SA_COLORS.muted, fontSize: "0.8125rem", whiteSpace: "nowrap" }}>
+                      {formatDate(u.last_sign_in)}
+                    </td>
+                    <td style={{ padding: "0.75rem 1rem", textAlign: "center" }}>{u.total_sessions}</td>
+                    <td style={{ padding: "0.75rem 1rem", textAlign: "center" }}>{u.total_orders}</td>
+                    <td style={{ padding: "0.75rem 1rem" }}>
+                      <div style={{ display: "flex", gap: "0.375rem", flexWrap: "wrap" }}>
+                        <Link
+                          href={`/${saPath}/users/${u.id}`}
+                          style={{ ...btnStyle("primary"), textDecoration: "none", display: "inline-block" }}
+                        >
+                          View
+                        </Link>
+                        <button style={btnStyle(u.is_banned ? "primary" : "danger")} onClick={() => setBanTarget(u)}>
+                          {u.is_banned ? "Unban" : "Ban"}
+                        </button>
+                        <button style={btnStyle("danger")} onClick={() => { setDeleteTarget(u); setDeleteConfirmWa(""); }}>
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Ban Confirmation Modal */}
+      {banTarget && (
+        <div
+          style={{
+            position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)",
+            display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50, padding: "1rem",
+          }}
+        >
+          <div style={{ background: SA_COLORS.surface, border: `1px solid ${SA_COLORS.border}`, borderRadius: "1rem", padding: "1.5rem", maxWidth: "400px", width: "100%" }}>
+            <h3 style={{ fontWeight: 700, marginBottom: "0.75rem", color: SA_COLORS.text }}>
+              {banTarget.is_banned ? "Unban" : "Ban"} User
+            </h3>
+            <p style={{ color: SA_COLORS.muted, fontSize: "0.9375rem", marginBottom: "1.25rem" }}>
+              {banTarget.is_banned
+                ? `Unban "${banTarget.business_name}"? They will be able to log in again.`
+                : `Ban "${banTarget.business_name}"? They will be unable to log in and all their sessions will be deactivated.`}
+            </p>
+            <div style={{ display: "flex", gap: "0.75rem" }}>
+              <button
+                onClick={() => setBanTarget(null)}
+                style={{ flex: 1, ...btnStyle("ghost"), padding: "0.625rem" }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleBan}
+                disabled={actionLoading}
+                style={{
+                  flex: 1,
+                  background: banTarget.is_banned ? "rgba(104,211,145,0.2)" : "rgba(252,129,129,0.2)",
+                  color: banTarget.is_banned ? SA_COLORS.success : SA_COLORS.danger,
+                  border: "none", borderRadius: "0.5rem", padding: "0.625rem",
+                  fontWeight: 600, cursor: actionLoading ? "not-allowed" : "pointer",
+                }}
+              >
+                {actionLoading ? "…" : banTarget.is_banned ? "Unban" : "Ban"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deleteTarget && (
+        <div
+          style={{
+            position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)",
+            display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50, padding: "1rem",
+          }}
+        >
+          <div style={{ background: SA_COLORS.surface, border: `1px solid ${SA_COLORS.border}`, borderRadius: "1rem", padding: "1.5rem", maxWidth: "440px", width: "100%" }}>
+            <h3 style={{ fontWeight: 700, marginBottom: "0.75rem", color: SA_COLORS.danger }}>
+              Delete User — Permanent
+            </h3>
+            <p style={{ color: SA_COLORS.muted, fontSize: "0.9375rem", marginBottom: "0.75rem" }}>
+              This will permanently delete <strong style={{ color: SA_COLORS.text }}>{deleteTarget.business_name}</strong> and
+              ALL their data (sessions, items, orders, payments). This cannot be undone.
+            </p>
+            <p style={{ color: SA_COLORS.text, fontSize: "0.875rem", marginBottom: "0.5rem" }}>
+              Type the WA number <strong>{deleteTarget.wa_number}</strong> to confirm:
+            </p>
+            <input
+              type="text"
+              value={deleteConfirmWa}
+              onChange={(e) => setDeleteConfirmWa(e.target.value)}
+              placeholder={deleteTarget.wa_number}
+              style={{ ...inputStyle, width: "100%", marginBottom: "1rem" }}
+            />
+            <div style={{ display: "flex", gap: "0.75rem" }}>
+              <button
+                onClick={() => { setDeleteTarget(null); setDeleteConfirmWa(""); }}
+                style={{ flex: 1, ...btnStyle("ghost"), padding: "0.625rem" }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleteConfirmWa !== deleteTarget.wa_number || actionLoading}
+                style={{
+                  flex: 1,
+                  background: "rgba(252,129,129,0.2)",
+                  color: SA_COLORS.danger,
+                  border: "none", borderRadius: "0.5rem", padding: "0.625rem",
+                  fontWeight: 600,
+                  cursor: deleteConfirmWa !== deleteTarget.wa_number || actionLoading ? "not-allowed" : "pointer",
+                  opacity: deleteConfirmWa !== deleteTarget.wa_number ? 0.5 : 1,
+                }}
+              >
+                {actionLoading ? "Deleting…" : "Delete Forever"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/sa/layout.tsx
+++ b/app/sa/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function SaRootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ background: "#0F1117", minHeight: "100vh", color: "#E2E8F0" }}>
+      {children}
+    </div>
+  );
+}

--- a/app/sa/login/page.tsx
+++ b/app/sa/login/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function SaLoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  // Determine SA path prefix from the current URL for redirects
+  const getSaPath = () => {
+    if (typeof window === "undefined") return "";
+    const parts = window.location.pathname.split("/");
+    return parts[1] || "";
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/sa/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Login failed");
+      } else {
+        const saPath = getSaPath();
+        router.push(`/${saPath}/users`);
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      style={{ background: "#0F1117", minHeight: "100vh" }}
+      className="flex items-center justify-center px-4"
+    >
+      <div style={{ width: "100%", maxWidth: "400px" }}>
+        <div className="text-center mb-8">
+          <div
+            style={{ color: "#6C63FF", fontSize: "1.75rem", fontWeight: 800, letterSpacing: "-0.03em" }}
+          >
+            Waitlistku Admin
+          </div>
+          <p style={{ color: "#718096", fontSize: "0.875rem", marginTop: "0.5rem" }}>
+            Restricted access only
+          </p>
+        </div>
+
+        <div
+          style={{
+            background: "#1A1D27",
+            border: "1px solid #2D3148",
+            borderRadius: "1rem",
+            padding: "2rem",
+          }}
+        >
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label style={{ color: "#E2E8F0", fontSize: "0.875rem", fontWeight: 500 }} className="block mb-1.5">
+                Email
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="username"
+                style={{
+                  width: "100%",
+                  background: "#0F1117",
+                  border: "1px solid #2D3148",
+                  borderRadius: "0.625rem",
+                  padding: "0.625rem 0.875rem",
+                  color: "#E2E8F0",
+                  fontSize: "0.875rem",
+                  outline: "none",
+                }}
+                onFocus={(e) => (e.target.style.borderColor = "#6C63FF")}
+                onBlur={(e) => (e.target.style.borderColor = "#2D3148")}
+              />
+            </div>
+
+            <div>
+              <label style={{ color: "#E2E8F0", fontSize: "0.875rem", fontWeight: 500 }} className="block mb-1.5">
+                Password
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="current-password"
+                style={{
+                  width: "100%",
+                  background: "#0F1117",
+                  border: "1px solid #2D3148",
+                  borderRadius: "0.625rem",
+                  padding: "0.625rem 0.875rem",
+                  color: "#E2E8F0",
+                  fontSize: "0.875rem",
+                  outline: "none",
+                }}
+                onFocus={(e) => (e.target.style.borderColor = "#6C63FF")}
+                onBlur={(e) => (e.target.style.borderColor = "#2D3148")}
+              />
+            </div>
+
+            {error && (
+              <div
+                style={{
+                  background: "rgba(252,129,129,0.1)",
+                  border: "1px solid rgba(252,129,129,0.3)",
+                  borderRadius: "0.5rem",
+                  padding: "0.625rem 0.875rem",
+                  color: "#FC8181",
+                  fontSize: "0.875rem",
+                }}
+              >
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              style={{
+                width: "100%",
+                background: loading ? "#4a46b8" : "#6C63FF",
+                color: "#fff",
+                fontWeight: 600,
+                fontSize: "0.9375rem",
+                padding: "0.75rem",
+                borderRadius: "0.75rem",
+                border: "none",
+                cursor: loading ? "not-allowed" : "pointer",
+                transition: "background 0.15s",
+                marginTop: "0.5rem",
+              }}
+            >
+              {loading ? "Signing in..." : "Sign In"}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,11 +3,35 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useLang } from "@/lib/LanguageContext";
 import toast from "react-hot-toast";
+import { useState, useEffect } from "react";
+
+interface MeData {
+  business_name: string;
+  role: string;
+}
 
 export default function Navbar({ isLoggedIn }: { isLoggedIn?: boolean }) {
   const { lang, locale, toggleLang } = useLang();
   const pathname = usePathname();
   const router = useRouter();
+  const [me, setMe] = useState<MeData | null>(null);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    fetch("/api/auth/me")
+      .then((r) => {
+        if (r.status === 403) {
+          // Banned — force logout
+          fetch("/api/auth/logout", { method: "POST" }).then(() => {
+            router.push("/login?banned=1");
+          });
+          return null;
+        }
+        return r.ok ? r.json() : null;
+      })
+      .then((data) => data && setMe(data))
+      .catch(() => null);
+  }, [isLoggedIn]);
 
   const handleLogout = async () => {
     await fetch("/api/auth/logout", { method: "POST" });
@@ -35,13 +59,29 @@ export default function Navbar({ isLoggedIn }: { isLoggedIn?: boolean }) {
             <>
               <Link
                 href="/dashboard"
-                className={`text-sm font-medium px-3 py-1.5 rounded-lg transition-colors ${
+                className={`text-sm font-medium px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5 ${
                   pathname.startsWith("/dashboard")
                     ? "bg-teal-600 text-white"
                     : "text-gray-600 hover:text-teal-600"
                 }`}
               >
-                {lang.nav_dashboard}
+                {me?.business_name || lang.nav_dashboard}
+                {me?.role === "tester" && (
+                  <span
+                    style={{
+                      background: "rgba(108,99,255,0.15)",
+                      color: "#6C63FF",
+                      border: "1px solid rgba(108,99,255,0.4)",
+                      borderRadius: "999px",
+                      padding: "0 0.4rem",
+                      fontSize: "0.65rem",
+                      fontWeight: 700,
+                      letterSpacing: "0.05em",
+                    }}
+                  >
+                    TESTER
+                  </span>
+                )}
               </Link>
               <button
                 onClick={handleLogout}

--- a/components/sa/SaSidebar.tsx
+++ b/components/sa/SaSidebar.tsx
@@ -1,0 +1,152 @@
+"use client";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+
+const NAV_ITEMS = [
+  { label: "Users", href: "users", icon: "👥" },
+  { label: "Transactions", href: "transactions", icon: "💳" },
+];
+
+export default function SaSidebar({ saPath }: { saPath: string }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [collapsed, setCollapsed] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  const handleLogout = async () => {
+    setLoggingOut(true);
+    await fetch("/api/sa/auth/logout", { method: "POST" });
+    router.push(`/${saPath}/login`);
+  };
+
+  const isActive = (href: string) => pathname.includes(`/sa/${href}`);
+
+  return (
+    <aside
+      style={{
+        width: collapsed ? "4rem" : "14rem",
+        background: "#1A1D27",
+        borderRight: "1px solid #2D3148",
+        display: "flex",
+        flexDirection: "column",
+        transition: "width 0.2s",
+        flexShrink: 0,
+        minHeight: "100vh",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: collapsed ? "1.25rem 0.75rem" : "1.25rem 1.25rem",
+          borderBottom: "1px solid #2D3148",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "0.5rem",
+        }}
+      >
+        {!collapsed && (
+          <span
+            style={{
+              color: "#6C63FF",
+              fontWeight: 800,
+              fontSize: "1rem",
+              letterSpacing: "-0.02em",
+              whiteSpace: "nowrap",
+            }}
+          >
+            Waitlistku Admin
+          </span>
+        )}
+        <button
+          onClick={() => setCollapsed((c) => !c)}
+          style={{
+            background: "none",
+            border: "1px solid #2D3148",
+            borderRadius: "0.375rem",
+            color: "#718096",
+            cursor: "pointer",
+            padding: "0.25rem 0.375rem",
+            fontSize: "0.75rem",
+            flexShrink: 0,
+          }}
+          title={collapsed ? "Expand" : "Collapse"}
+        >
+          {collapsed ? "▶" : "◀"}
+        </button>
+      </div>
+
+      {/* Nav */}
+      <nav style={{ flex: 1, padding: "0.75rem 0.5rem" }}>
+        {NAV_ITEMS.map((item) => {
+          const active = isActive(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={`/${saPath}/${item.href}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.625rem",
+                padding: collapsed ? "0.625rem" : "0.625rem 0.875rem",
+                borderRadius: "0.625rem",
+                marginBottom: "0.25rem",
+                background: active ? "rgba(108,99,255,0.15)" : "transparent",
+                color: active ? "#6C63FF" : "#718096",
+                fontWeight: active ? 600 : 400,
+                fontSize: "0.9375rem",
+                textDecoration: "none",
+                transition: "background 0.15s, color 0.15s",
+                justifyContent: collapsed ? "center" : "flex-start",
+              }}
+              onMouseEnter={(e) => {
+                if (!active) {
+                  (e.currentTarget as HTMLElement).style.background = "rgba(108,99,255,0.08)";
+                  (e.currentTarget as HTMLElement).style.color = "#E2E8F0";
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!active) {
+                  (e.currentTarget as HTMLElement).style.background = "transparent";
+                  (e.currentTarget as HTMLElement).style.color = "#718096";
+                }
+              }}
+            >
+              <span style={{ fontSize: "1.125rem" }}>{item.icon}</span>
+              {!collapsed && <span>{item.label}</span>}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Logout */}
+      <div style={{ padding: "0.75rem 0.5rem", borderTop: "1px solid #2D3148" }}>
+        <button
+          onClick={handleLogout}
+          disabled={loggingOut}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "0.625rem",
+            padding: collapsed ? "0.625rem" : "0.625rem 0.875rem",
+            borderRadius: "0.625rem",
+            width: "100%",
+            background: "none",
+            border: "none",
+            color: "#FC8181",
+            fontSize: "0.9375rem",
+            cursor: "pointer",
+            justifyContent: collapsed ? "center" : "flex-start",
+            transition: "background 0.15s",
+          }}
+          onMouseEnter={(e) => ((e.currentTarget as HTMLElement).style.background = "rgba(252,129,129,0.1)")}
+          onMouseLeave={(e) => ((e.currentTarget as HTMLElement).style.background = "none")}
+        >
+          <span style={{ fontSize: "1.125rem" }}>🚪</span>
+          {!collapsed && <span>{loggingOut ? "Logging out..." : "Logout"}</span>}
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/lib/saAuth.ts
+++ b/lib/saAuth.ts
@@ -1,0 +1,40 @@
+import { SignJWT, jwtVerify } from "jose";
+import { NextRequest } from "next/server";
+
+const SA_SECRET = new TextEncoder().encode(
+  process.env.SA_JWT_SECRET || "sa-secret-change-in-production"
+);
+
+const SA_COOKIE = "sa_token";
+
+export async function signSaToken(): Promise<string> {
+  return new SignJWT({ role: "superadmin" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("8h")
+    .sign(SA_SECRET);
+}
+
+export async function verifySaToken(token: string): Promise<boolean> {
+  try {
+    await jwtVerify(token, SA_SECRET);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getSaTokenFromRequest(req: NextRequest): Promise<string | undefined> {
+  return req.cookies.get(SA_COOKIE)?.value;
+}
+
+export function getSaCookieOptions() {
+  return {
+    name: SA_COOKIE,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 60 * 60 * 8, // 8 hours
+  };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,19 +5,88 @@ const JWT_SECRET = new TextEncoder().encode(
   process.env.JWT_SECRET || "waitlistku-secret-key-change-in-production"
 );
 
+const SA_SECRET = new TextEncoder().encode(
+  process.env.SA_JWT_SECRET || "sa-secret-change-in-production"
+);
+
 export async function middleware(req: NextRequest) {
-  const token = req.cookies.get("waitlistku_token")?.value;
-  if (!token) {
-    return NextResponse.redirect(new URL("/login", req.url));
+  const { pathname } = req.nextUrl;
+
+  // ── Owner dashboard protection ──────────────────────────────────────
+  if (pathname.startsWith("/dashboard")) {
+    const token = req.cookies.get("waitlistku_token")?.value;
+    if (!token) return NextResponse.redirect(new URL("/login", req.url));
+    try {
+      const { payload } = await jwtVerify(token, JWT_SECRET);
+      const userId = (payload as { userId?: string }).userId;
+
+      // Check is_banned via Supabase REST API
+      if (userId) {
+        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+        const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+        if (supabaseUrl && serviceKey) {
+          try {
+            const resp = await fetch(
+              `${supabaseUrl}/rest/v1/users?id=eq.${userId}&select=is_banned`,
+              { headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` } }
+            );
+            if (resp.ok) {
+              const rows = await resp.json() as { is_banned: boolean }[];
+              if (rows[0]?.is_banned) {
+                const res = NextResponse.redirect(new URL("/login?banned=1", req.url));
+                res.cookies.delete("waitlistku_token");
+                return res;
+              }
+            }
+          } catch {
+            // If DB check fails, allow through (don't block legitimate users)
+          }
+        }
+      }
+
+      return NextResponse.next();
+    } catch {
+      return NextResponse.redirect(new URL("/login", req.url));
+    }
   }
-  try {
-    await jwtVerify(token, JWT_SECRET);
-    return NextResponse.next();
-  } catch {
-    return NextResponse.redirect(new URL("/login", req.url));
+
+  // ── Superadmin panel ────────────────────────────────────────────────
+  const SA_PATH = process.env.SUPERADMIN_PATH || "sa-panel-x7k2q";
+
+  // Block direct access to internal /sa/* routes
+  if (pathname.startsWith("/sa/") || pathname === "/sa") {
+    return NextResponse.redirect(new URL("/", req.url));
   }
+
+  // Handle SUPERADMIN_PATH requests
+  if (pathname === `/${SA_PATH}` || pathname.startsWith(`/${SA_PATH}/`)) {
+    const subpath = pathname.slice(SA_PATH.length + 1) || "/";
+    const loginUrl = new URL(`/${SA_PATH}/login`, req.url);
+
+    // Allow login page through without token check
+    if (subpath === "/login" || subpath === "/login/") {
+      return NextResponse.rewrite(new URL("/sa/login", req.url));
+    }
+
+    // All other SA routes require valid sa_token
+    const saToken = req.cookies.get("sa_token")?.value;
+    if (!saToken) return NextResponse.redirect(loginUrl);
+    try {
+      await jwtVerify(saToken, SA_SECRET);
+    } catch {
+      const res = NextResponse.redirect(loginUrl);
+      res.cookies.delete("sa_token");
+      return res;
+    }
+
+    // Rewrite to internal /sa/* path while keeping URL unchanged in browser
+    const internalPath = subpath === "/" ? "/sa" : `/sa${subpath}`;
+    return NextResponse.rewrite(new URL(internalPath, req.url));
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*"],
+  matcher: ["/dashboard/:path*", "/sa/:path*", "/:path*"],
 };

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -106,3 +106,8 @@ create index on owner_payments(session_id, payment_status);
 -- alter table items add column if not exists is_visible boolean default true;
 -- alter table sessions add column if not exists primary_color text;
 -- alter table sessions add column if not exists accent_color text;
+
+-- Superadmin additions (run in Supabase SQL Editor)
+alter table users add column if not exists role text check (role in ('personal','tester')) default 'personal';
+alter table users add column if not exists is_banned boolean default false;
+alter table users add column if not exists last_sign_in timestamptz;


### PR DESCRIPTION
- Secret-URL access via SUPERADMIN_PATH env var with middleware rewrite
- Standalone dark-theme login (sa_token httpOnly cookie, separate from owner JWT)
- Sidebar layout with Users and Transactions navigation
- Users list: search/filter, ban/unban with confirmation, hard delete (WA number confirm)
- User detail: profile edit, payment history with approve, sessions accordion, danger zone
- Transactions: global view across all users, single and bulk approve
- All SA API routes under /api/sa/* independently verify sa_token using service role key
- Owner login now sets last_sign_in and blocks banned users (403 with Indonesian message)
- Dashboard middleware checks is_banned on every request; banned users get cookie cleared
- Tester role bypasses all paywall checks in orders list and export endpoints
- TESTER badge shown in owner dashboard navbar next to business name
- DB migrations: users.role, users.is_banned, users.last_sign_in columns added

https://claude.ai/code/session_01EaZfzQVkmbUW8crVuND2n7