### PR TITLE
Use og-default.png as fallback OG image when session has no custom th…

### DIFF
--- a/app/p/[slug]/page.tsx
+++ b/app/p/[slug]/page.tsx
@@ -13,7 +13,10 @@ export async function generateMetadata(
 
   const title = session?.og_title || session?.title || "Preorder";
   const description = session?.og_description || session?.intro_text || "Halaman preorder Waitlistku";
-  const image = session?.og_image || undefined;
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "";
+  const defaultImage = appUrl ? `${appUrl}/og-default.png` : undefined;
+  const image = session?.og_image || defaultImage;
 
   return {
     title,
@@ -22,10 +25,10 @@ export async function generateMetadata(
       title,
       description,
       type: "website",
-      ...(image ? { images: [{ url: image }] } : {}),
+      images: image ? [{ url: image, width: 1200, height: 630 }] : [],
     },
     twitter: {
-      card: image ? "summary_large_image" : "summary",
+      card: "summary_large_image",
       title,
       description,
       ...(image ? { images: [image] } : {}),


### PR DESCRIPTION
…umbnail

Falls back to NEXT_PUBLIC_APP_URL/og-default.png so every shared link gets the branded thumbnail unless the owner overrides it.

https://claude.ai/code/session_012SiXCBfkFqqH7UmS3hcC95